### PR TITLE
fix: discordjs interaction not found error

### DIFF
--- a/src/commands/healthcheck.ts
+++ b/src/commands/healthcheck.ts
@@ -9,7 +9,7 @@ const healthCheckCommand: ICommand = {
 
 async function healthCheckHandler(): Promise<boolean> {
 	try {
-		await ping(config.get("minecraft.address"), config.get("minecraft.port"));
+		await ping(config.get("minecraft.address"), config.get("minecraft.port"), {timeout: 3000});
 		return true
 	} catch (e) {
 		return false

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ async function bootstrap() {
 			if (!interaction.isChatInputCommand()) return
 
 			let message
+			await interaction.reply("잠시만 기다려보게나! 내 금방 알아오겠네");
 			switch (interaction.commandName) {
 				case healthCheckCommand.name:
 					const isHealthy = await healthCheckHandler()
@@ -35,8 +36,8 @@ async function bootstrap() {
 					message = 'unknown command'
 			}
 
-			await interaction.reply(message);
 			console.log(interaction.commandName, message)
+			await interaction.followUp(message);
 		})
 
 		await client.login(TOKEN)


### PR DESCRIPTION
서버가 켜져있는 경우 ping 을 날렸을 때 즉각 응답이 왔지만 서버가 꺼져있는 경우 무한정하게 대기하는 이슈 발생

10000ms 이후 자동 종료됐고 함수는 False 반환했지만 discordjs 에서 해당 interaction 이 not found 로 인식되는 상황.
interaction 이 특정 시간동안 반응이 없으면 자동 종료되는 것 같음.

기다리는 건 어쩔 수 없기 때문에 일단 기다리라는 메세지를 하나 띄우고 ping 날린 후에 timeout 되면 그 때 서버가 안열렸다고 판단하여 다시 유저에게 메세지 전송하는 방식으로 변경